### PR TITLE
PHP5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     "autoload": {
         "psr-0": { },
         "files": [
+            "src/functions.ole.php",
             "src/class.ole.php",
             "src/class.ole_pps.php",
             "src/class.ole_pps_dir.php",
             "src/class.ole_pps_file.php",
-            "src/class.ole_pps_root.php",
-            "src/functions.ole.php"
+            "src/class.ole_pps_root.php"            
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
             "src/class.ole_pps_dir.php",
             "src/class.ole_pps_file.php",
             "src/class.ole_pps_root.php",
-            "src/function.ole.php"
+            "src/functions.ole.php"
         ]
     }
 }

--- a/src/class.ole_pps_root.php
+++ b/src/class.ole_pps_root.php
@@ -302,7 +302,7 @@ function _savePpsSetPnt2(&$aThis, &$raList, $rhInfo) {
       return 0xFFFFFFFF;
   } elseif (sizeof($aThis)==1) {
 #1.2 Just Only one
-      array_push($raList, &$aThis[0]);
+      array_push($raList, $aThis[0]);
       $aThis[0]->No = sizeof($raList)-1;
       $aThis[0]->PrevPps = 0xFFFFFFFF;
       $aThis[0]->NextPps = 0xFFFFFFFF;
@@ -339,7 +339,7 @@ function _savePpsSetPnt2s(&$aThis, &$raList, $rhInfo) {
       return 0xFFFFFFFF;
   } elseif (sizeof($aThis)==1) {
 #1.2 Just Only one
-      array_push($raList, &$aThis[0]);
+      array_push($raList, $aThis[0]);
       $aThis[0]->No = sizeof($raList)-1;
       $aThis[0]->PrevPps = 0xFFFFFFFF;
       $aThis[0]->NextPps = 0xFFFFFFFF;
@@ -377,7 +377,7 @@ function _savePpsSetPnt(&$aThis, &$raList, $rhInfo) {
       return 0xFFFFFFFF;
   } elseif (sizeof($aThis)==1) {
 #1.2 Just Only one
-      array_push($raList, &$aThis[0]);
+      array_push($raList, $aThis[0]);
       $aThis[0]->No = sizeof($raList)-1;
       $aThis[0]->PrevPps = 0xFFFFFFFF;
       $aThis[0]->NextPps = 0xFFFFFFFF;
@@ -411,7 +411,7 @@ function _savePpsSetPnt1(&$aThis, &$raList, $rhInfo) {
       return 0xFFFFFFFF;
   } elseif (sizeof($aThis)==1) {
 #1.2 Just Only one
-      array_push($raList, &$aThis[0]);
+      array_push($raList, $aThis[0]);
       $aThis[0]->No = sizeof($raList)-1;
       $aThis[0]->PrevPps = 0xFFFFFFFF;
       $aThis[0]->NextPps = 0xFFFFFFFF;


### PR DESCRIPTION
Because I required this library on a PHP 5.x project.

Changed the "composer.json" file to put "functions.ole.php" to the top of the list, to prevent an "already defined function" error. Correct the "function.ole.php" to "functions.ole.php".

Changed the calls with "pass by reference" raising errors, because calling function with reference sign was deprecated since PHP 5.3 and removed since PHP 5.4 (http://php.net/manual/en/language.references.pass.php).
